### PR TITLE
Fix command palette modification for keymap path

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -23,7 +23,7 @@
         "caption": "Preferences: MoveTab Key Bindings",
         "command": "edit_settings",
         "args": {
-            "base_file": "Packages/MoveTab/Default (${platform}).sublime-keymap",
+            "base_file": "${packages}/MoveTab/Default (${platform}).sublime-keymap",
             "default": "[\n\t$0\n]",
         },
     },


### PR DESCRIPTION
This pull request fixes errors in the command palette due to a hardcoded path. 

![Screenshot from 2024-03-10 20-39-24](https://github.com/SublimeText/MoveTab/assets/45518628/043d11f1-608a-49c6-89db-e7674c352580)

![Screenshot from 2024-03-10 20-40-29](https://github.com/SublimeText/MoveTab/assets/45518628/fb528b71-434a-4220-9e62-705bfdf8af5c)

The "base_file" path is now dynamically set using ${packages}, ensuring correct keymap file location across different Sublime Text installations.

This change resolves path-related errors and improves command palette functionality.