### PR TITLE
Add new preferences menu for edit key bindings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,26 @@
+[
+    {
+        "id": "preferences",
+        "children": [
+            {
+                "id": "package-settings",
+                "children": [
+                    {
+                        "caption": "Move tab",
+                        "children": [
+                            {
+                                "args":
+                                {
+                                    "base_file": "${packages}/MoveTab/Default (${platform}).sublime-keymap",
+                                    "default": "[\n\t$0\n]",
+                                },
+                                "caption": "Key Bindings",
+                                "command": "edit_settings"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Add a new preferences menu for editing key bindings in the MoveTab plugin. The menu includes a dedicated section for managing key bindings, enhancing user customization options.

![MoveTab_preferences](https://github.com/SublimeText/MoveTab/assets/45518628/7d945da9-4f9a-4888-9ef6-1f4cf1f477eb)

 If this modification aligns with the project's goals and standards, it could be accepted for integration into the MoveTab plugin :)